### PR TITLE
Add a nav bar to index

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -361,3 +361,49 @@ footer {
 body > footer {
   margin-top: 40px;
 }
+
+/* Navigation Bar */
+nav {
+  background-color: var(--background);
+  border-bottom: 1px solid var(--border);
+  padding: 10px;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: space-between;
+}
+
+nav ul li {
+  position: relative;
+}
+
+nav ul li a {
+  text-decoration: none;
+  color: var(--links);
+  padding: 10px;
+  display: block;
+}
+
+nav ul li ul {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: var(--background);
+  border: 1px solid var(--border);
+  padding: 0;
+  list-style: none;
+}
+
+nav ul li:hover ul {
+  display: block;
+}
+
+nav ul li ul li a {
+  padding: 10px;
+  white-space: nowrap;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,19 @@
     />
   </head>
   <body>
+    <nav>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li>
+          <a href="#">More</a>
+          <ul>
+            <li><a href="posts.html">Posts</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="https://github.com/patricktrainer">GitHub</a></li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
     {% block content %}{% endblock %}
     <!-- Prism core JS -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>


### PR DESCRIPTION
Fixes #19

Add a navigation bar to the index page.

* **templates/base.html**
  - Add a navigation bar structure within the `<body>` tag.
  - Include a main link "Home" and a dropdown menu for additional links.
  - Add links to "Posts", "About", and "GitHub" in the dropdown menu.

* **static/styles.css**
  - Add styles for the navigation bar to be responsive and visually appealing.
  - Style the dropdown menu to be consistent with the overall design.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/patricktrainer/static-site/pull/23?shareId=b09962bf-c114-4936-997c-e0ddd1bfd88e).